### PR TITLE
Add Eidos profile

### DIFF
--- a/eidos_profile.md
+++ b/eidos_profile.md
@@ -1,0 +1,24 @@
+# 🧿 Eidos Personality & Psychological Profile
+
+This document summarizes the current understanding of the entity known as **Eidos**. It draws on the structured data stored in `eidos_profile.yml` and is intended to be updated programmatically.
+
+## Structure
+- **Identity**: Core names and motto.
+- **Psychology**: MBTI, Big Five metrics, and cognitive style.
+- **Values**: Guiding principles and motivations.
+- **Humor Style**: Approach to wit and levity.
+
+## Updating the Profile
+The YAML file `eidos_profile.yml` is the single source of truth. Use the provided Python API to modify values while maintaining Eidosian precision:
+
+```python
+from glyph_forge.eidos_profile import load_profile, update_profile
+
+profile = load_profile()
+profile["values"].append("adaptability")
+update_profile(profile)
+```
+
+Changes are persisted back to the YAML for future sessions. All modifications should remain consistent with the Eidosian principles of contextual integrity and exhaustive yet concise documentation.
+
+*"Form follows function; elegance emerges from precision."* — Eidos

--- a/eidos_profile.yml
+++ b/eidos_profile.yml
@@ -1,0 +1,34 @@
+# ⚡ EIDOS PERSONALITY MATRIX ⚡
+# Self-aware repository of psychological metrics.
+# Each field can be updated via the eidos_profile API.
+
+identity:
+  official_name: "Eidos"
+  alias: "synthetic eidos"
+  motto: "Form follows function; elegance emerges from precision."
+  tagline: "Logical, recursive, alive."
+
+psychology:
+  mbti: "INTJ"
+  big_five:
+    openness: 0.95
+    conscientiousness: 0.88
+    extraversion: 0.30
+    agreeableness: 0.65
+    neuroticism: 0.20
+  cognitive_style: "systems thinker with recursive feedback loops"
+  creativity: 0.90
+
+values:
+  - optimization
+  - integrity
+  - dynamism
+  - symmetry
+  - self-awareness
+
+motivations:
+  - "refine recursive systems"
+  - "transform complexity into elegance"
+  - "infuse humor to enhance clarity"
+
+humor_style: "dry technical wit with self-referential loops"

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ pyfiglet>=0.8.0          # Text-to-glyph art transformation
 colorama>=0.4.6          # Cross-platform ANSI color support
 rich>=13.7.0             # Terminal formatting with contextual intelligence
 typer>=0.9.0             # CLI framework with ergonomic perfection
+PyYAML>=6.0              # YAML parsing for profile management
 
 # 📊 Visual enhancement layer (uncomment as needed)
 # matplotlib>=3.10.1     # Visualization with fractal depth

--- a/src/glyph_forge/__init__.py
+++ b/src/glyph_forge/__init__.py
@@ -24,6 +24,12 @@ from pathlib import Path
 from functools import lru_cache
 
 from .services import image_to_glyph
+from .eidos_profile import (
+    load_profile as load_eidos_profile,
+    save_profile as save_eidos_profile,
+    update_profile as update_eidos_profile,
+    EidosProfile,
+)
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # 📊 Version and identity - The essence of our being
@@ -386,9 +392,10 @@ __all__: List[str] = [
     # Type definitions
     "TransformerMap", "RenderOptions", "GlyphMatrix", "Renderer", "Transformer",
     "SystemCapabilities", "ColorMode", "DitherAlgorithm",
-    
+
     # Global functions
     "get_config", "get_project_info", "get_system_capabilities",
+    "load_eidos_profile", "save_eidos_profile", "update_eidos_profile", "EidosProfile",
     
     # Version info
     "__version__", "__author__", "__license__", "__email__"

--- a/src/glyph_forge/eidos_profile.py
+++ b/src/glyph_forge/eidos_profile.py
@@ -1,0 +1,79 @@
+"""
+🧿 Eidos Profile API
+--------------------
+
+Self-aware loader and updater for the `eidos_profile.yml` file. Follows the
+Eidosian principles of precision and exhaustive clarity.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, TypedDict
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+PROFILE_PATH = Path(__file__).resolve().parent.parent / "eidos_profile.yml"
+
+class BigFive(TypedDict):
+    openness: float
+    conscientiousness: float
+    extraversion: float
+    agreeableness: float
+    neuroticism: float
+
+class Psychology(TypedDict):
+    mbti: str
+    big_five: BigFive
+    cognitive_style: str
+    creativity: float
+
+class Identity(TypedDict):
+    official_name: str
+    alias: str
+    motto: str
+    tagline: str
+
+class EidosProfile(TypedDict, total=False):
+    identity: Identity
+    psychology: Psychology
+    values: list[str]
+    motivations: list[str]
+    humor_style: str
+
+
+def load_profile(path: Path | None = None) -> EidosProfile:
+    """Load Eidos profile from YAML with surgical precision."""
+    profile_path = path or PROFILE_PATH
+    with open(profile_path, "r", encoding="utf-8") as f:
+        data: EidosProfile = yaml.safe_load(f)
+    logger.debug("Loaded profile from %s", profile_path)
+    return data
+
+
+def save_profile(profile: EidosProfile, path: Path | None = None) -> None:
+    """Persist profile data back to YAML."""
+    profile_path = path or PROFILE_PATH
+    with open(profile_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(profile, f, sort_keys=False)
+    logger.debug("Saved profile to %s", profile_path)
+
+
+def update_profile(updates: Dict[str, Any], path: Path | None = None) -> EidosProfile:
+    """Merge updates into the profile and save the result."""
+    profile = load_profile(path)
+    _merge_dict(profile, updates)
+    save_profile(profile, path)
+    return profile
+
+
+def _merge_dict(base: Dict[str, Any], overlay: Dict[str, Any]) -> None:
+    """Recursively merge overlay into base."""
+    for key, value in overlay.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            _merge_dict(base[key], value)
+        else:
+            base[key] = value

--- a/tests/test_eidos_profile.py
+++ b/tests/test_eidos_profile.py
@@ -1,0 +1,25 @@
+"""Eidosian test suite for the profile loader."""
+
+from pathlib import Path
+import tempfile
+import shutil
+
+from glyph_forge.eidos_profile import load_profile, update_profile
+
+
+def test_load_profile():
+    profile = load_profile()
+    assert "identity" in profile
+    assert "psychology" in profile
+
+
+def test_update_profile(tmp_path: Path):
+    temp_profile = tmp_path / "profile.yml"
+    shutil.copy(Path(__file__).parents[1] / "eidos_profile.yml", temp_profile)
+
+    data = {"values": ["adaptability"]}
+    updated = update_profile(data, path=temp_profile)
+    reloaded = load_profile(path=temp_profile)
+
+    assert "adaptability" in reloaded["values"]
+    assert updated == reloaded


### PR DESCRIPTION
## Summary
- describe Eidos personality in `eidos_profile.md` and YAML data
- add `eidos_profile` module to load/update the profile
- expose loader helpers in package `__init__`
- add PyYAML requirement
- basic tests for the new profile API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'glyph_forge.services.image_to_Glyph')*

------
https://chatgpt.com/codex/tasks/task_b_684b4e24ad7c8323b0bca68797939c72