### PR TITLE
Add glyphfy CLI compatibility shim

### DIFF
--- a/project_scope.md
+++ b/project_scope.md
@@ -47,7 +47,7 @@ Essential processing components:
   - `colorama` → Cross-platform color handling
   - `typer` → CLI interface framework
 - **Performance**: 0.09s average image processing time
-- **Commands**: `glyphfy` & `bannerize` entry points
+- **Commands**: `imagize` & `bannerize` entry points (`glyphfy` remains as a compatibility shim)
 - **Configuration**: Runtime-adaptable parameters
 
 ## 📈 Release Timeline

--- a/project_structure.md
+++ b/project_structure.md
@@ -69,7 +69,8 @@ src/glyph_forge/
 │   └── glyph_forge_api.py  # Core interface - functionality access points
 ├── cli/                    # Command system - terminal interaction layer
 │   ├── __init__.py         # Command registry - interaction entry points
-│   ├── glyphfy.py          # Image transformer - pixels to glyphs
+│   ├── glyphfy.py          # Legacy shim -> forwards to imagize CLI
+│   ├── imagize.py          # Image transformer - pixels to glyphs
 │   └── bannerize.py        # Text enhancer - typography system
 ├── config/                 # Settings matrix - behavior control center
 │   ├── __init__.py         # Config registry - parameter discovery

--- a/src/glyph_forge/cli/glyphfy.py
+++ b/src/glyph_forge/cli/glyphfy.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Compatibility shim for legacy `glyphfy` command.
+
+This module forwards execution to :mod:`glyph_forge.cli.imagize` so that
+existing scripts depending on the old ``glyphfy`` entry point continue to
+operate without changes.
+"""
+
+from .imagize import main
+
+__all__ = ["main"]
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `glyph_forge.cli.glyphfy` shim to forward to `imagize`
- update project documentation to reflect the new shim

## Testing
- `pip install numpy pillow pyfiglet colorama rich typer PyYAML`
- `pytest -q` *(fails: expected call not found, FileNotFoundError, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_684c03bbf8348323abd40519552e0a92