### PR TITLE
Update docs for imagize alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ This document maps the evolution pathway of Glyph Forge through its structural i
 - Multi-format renderer ecosystem (Text, ANSI, HTML, SVG)
 - Terminal-aware color system with fallback pathways
 - Image processing pipeline with density mapping
-- CLI entry points: `glyphfy` and `bannerize`
+- CLI entry points: `imagize` (alias: `glyphfy`) and `bannerize`
 - Comprehensive type annotations across all interfaces
 - Documentation system with practical examples
 

--- a/project_scope.md
+++ b/project_scope.md
@@ -47,7 +47,7 @@ Essential processing components:
   - `colorama` → Cross-platform color handling
   - `typer` → CLI interface framework
 - **Performance**: 0.09s average image processing time
-- **Commands**: `glyphfy` & `bannerize` entry points
+- **Commands**: `imagize` & `bannerize` entry points (`glyphfy` remains as a compatibility alias)
 - **Configuration**: Runtime-adaptable parameters
 
 ## 📈 Release Timeline

--- a/project_structure.md
+++ b/project_structure.md
@@ -69,7 +69,7 @@ src/glyph_forge/
 │   └── glyph_forge_api.py  # Core interface - functionality access points
 ├── cli/                    # Command system - terminal interaction layer
 │   ├── __init__.py         # Command registry - interaction entry points
-│   ├── glyphfy.py          # Image transformer - pixels to glyphs
+│   ├── imagize.py          # Image transformer - pixels to glyphs (`glyphfy.py` retained as alias)
 │   └── bannerize.py        # Text enhancer - typography system
 ├── config/                 # Settings matrix - behavior control center
 │   ├── __init__.py         # Config registry - parameter discovery


### PR DESCRIPTION
## Summary
- update docs to call the primary CLI entry `imagize`
- mention `glyphfy` remains available as an alias

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_b_684c03c1963083238c7fc52316e3a3ae