### PR TITLE
Fix outdated comment path

### DIFF
--- a/tests/test_image_to_ascii.py
+++ b/tests/test_image_to_ascii.py
@@ -1,4 +1,4 @@
-# filepath: /home/lloyd/repos/glyph_forge/tests/test_image_to_Glyph.py
+# tests/test_image_to_ascii.py
 """
 ⚡ Eidosian Test Suite: ImageGlyphConverter ⚡
 


### PR DESCRIPTION
## Summary
- update path in `tests/test_image_to_ascii.py`

## Testing
- `pytest tests/test_image_to_ascii.py::TestImageGlyphConverter::test_predefined_charset -q` *(fails: expected call not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c03c2ae188323b92a372d66c4a4b7