### PR TITLE
Remove unused Glyph_FALLBACK constant

### DIFF
--- a/src/glyph_forge/core/style_manager.py
+++ b/src/glyph_forge/core/style_manager.py
@@ -106,14 +106,6 @@ BORDERS = {
     }
 }
 
-# Glyph fallback mapping for terminals without Unicode support
-Glyph_FALLBACK = {
-    "single": "Glyph",
-    "double": "Glyph",
-    "rounded": "Glyph",
-    "bold": "Glyph",
-}
-
 
 def apply_style(Glyph_art: str, style_name: str = "minimal", **kwargs: Any) -> str:
     """


### PR DESCRIPTION
## Summary
- delete dead code constant `Glyph_FALLBACK`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_684c03c45ce08323918b86f7247bef2d