### PR TITLE
Fix CLI bannerize import error

### DIFF
--- a/src/glyph_forge/cli/bannerize.py
+++ b/src/glyph_forge/cli/bannerize.py
@@ -20,6 +20,7 @@ from typing import List, Dict, Any, Optional, Tuple, Union
 import signal
 import threading
 from functools import wraps
+import typer
 
 # Ensure project path is in Python path for development mode
 project_root = Path(__file__).parent.parent.parent.parent


### PR DESCRIPTION
## Summary
- add missing `typer` import in `bannerize.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d8278aac08323a8bf40704b560364