### PR TITLE
Fix TUI dependencies and add rendering stubs

### DIFF
--- a/src/glyph_forge/renderers/__init__.py
+++ b/src/glyph_forge/renderers/__init__.py
@@ -1,0 +1,43 @@
+"""Minimal rendering utilities for Glyph Forge."""
+from __future__ import annotations
+from typing import List, Dict, Any
+
+GlyphMatrix = List[List[str]]
+
+class TextRenderer:
+    """Render glyph matrix as plain text."""
+    def render(self, matrix: GlyphMatrix, options: Dict[str, Any] | None = None) -> str:
+        return "\n".join("".join(row) for row in matrix)
+
+class HTMLRenderer:
+    """Render glyph matrix inside simple HTML <pre> block."""
+    def render(self, matrix: GlyphMatrix, options: Dict[str, Any] | None = None) -> str:
+        lines = ["<pre style='line-height:1; letter-spacing:0'>"]
+        for row in matrix:
+            lines.append("".join(row))
+            lines.append("<br>")
+        lines.append("</pre>")
+        return "".join(lines)
+
+class ANSIRenderer(TextRenderer):
+    """Alias to :class:`TextRenderer` for backward compatibility."""
+    pass
+
+class SVGRenderer:
+    """Render glyph matrix to a very basic SVG document."""
+    def render(self, matrix: GlyphMatrix, options: Dict[str, Any] | None = None) -> str:
+        char_width = (options or {}).get("char_width", 10)
+        char_height = (options or {}).get("char_height", 14)
+        width = max(len(row) for row in matrix) * char_width
+        height = len(matrix) * char_height
+        svg_lines = [
+            f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}">'
+        ]
+        for i, row in enumerate(matrix):
+            y = (i + 1) * char_height
+            text = "".join(row).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+            svg_lines.append(f'<text x="0" y="{y}" font-family="monospace">{text}</text>')
+        svg_lines.append("</svg>")
+        return "\n".join(svg_lines)
+
+__all__ = ["TextRenderer", "HTMLRenderer", "ANSIRenderer", "SVGRenderer"]

--- a/src/glyph_forge/transformers/__init__.py
+++ b/src/glyph_forge/transformers/__init__.py
@@ -1,0 +1,23 @@
+"""Placeholder transformer classes for Glyph Forge."""
+from __future__ import annotations
+from typing import Any, List
+
+GlyphMatrix = List[List[str]]
+
+class ImageTransformer:
+    def transform(self, source: Any, **options: Any) -> GlyphMatrix:
+        raise NotImplementedError
+
+class ColorMapper:
+    def transform(self, source: Any, **options: Any) -> GlyphMatrix:
+        raise NotImplementedError
+
+class DepthAnalyzer:
+    def transform(self, source: Any, **options: Any) -> GlyphMatrix:
+        raise NotImplementedError
+
+class EdgeDetector:
+    def transform(self, source: Any, **options: Any) -> GlyphMatrix:
+        raise NotImplementedError
+
+__all__ = ["ImageTransformer", "ColorMapper", "DepthAnalyzer", "EdgeDetector"]

--- a/src/glyph_forge/ui/glyph_forge.css
+++ b/src/glyph_forge/ui/glyph_forge.css
@@ -1,0 +1,4 @@
+/* Minimal styles for Glyph Forge TUI */
+Screen {
+    align: center middle;
+}

--- a/src/glyph_forge/ui/tui.py
+++ b/src/glyph_forge/ui/tui.py
@@ -5,7 +5,7 @@
 Hyper-efficient terminal user interface for Glyph art transformation.
 """
 from textual.app import App
-from textual.widgets import Header, Footer, Static, Button, Input, FileInput
+from textual.widgets import Header, Footer, Static, Button, Input
 from textual.containers import Container, Horizontal, Vertical, Grid
 from textual.screen import Screen
 from textual.reactive import reactive
@@ -92,7 +92,7 @@ class ImageConverterScreen(Screen):
         yield Container(
             Vertical(
                 Static("Image to Glyph Converter", classes="screen_title"),
-                FileInput(id="image_file"),
+                Input(placeholder="Path to image", id="image_file"),
                 Horizontal(
                     Button("Convert", id="btn_convert"),
                     Button("Back", id="btn_back"),

--- a/src/glyph_forge/utils/__init__.py
+++ b/src/glyph_forge/utils/__init__.py
@@ -1,0 +1,68 @@
+"""Utility helpers for Glyph Forge."""
+from .glyph_utils import (
+    sanitize_text,
+    resolve_style,
+    trim_margins,
+    center_Glyph_art,
+    measure_Glyph_art,
+    detect_box_borders,
+    get_terminal_size,
+    detect_text_color_support,
+    apply_ansi_style,
+)
+
+__all__ = [
+    "sanitize_text",
+    "resolve_style",
+    "trim_margins",
+    "center_Glyph_art",
+    "measure_Glyph_art",
+    "detect_box_borders",
+    "get_terminal_size",
+    "detect_text_color_support",
+    "apply_ansi_style",
+]
+import logging
+import time
+from typing import Any, Callable, Dict
+
+logger = logging.getLogger("glyph_forge")
+
+
+def setup_logger(level: str = "INFO") -> logging.Logger:
+    """Initialize and return a package logger."""
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    return logger
+
+
+def configure(*_args: Any, **_kwargs: Any) -> None:
+    """Placeholder configuration hook."""
+    return None
+
+
+def measure_performance(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Simple performance measurement decorator."""
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        start = time.perf_counter()
+        result = func(*args, **kwargs)
+        duration = time.perf_counter() - start
+        logger.debug("%s completed in %.2fms", func.__name__, duration * 1000)
+        return result
+
+    return wrapper
+
+
+def detect_capabilities() -> Dict[str, Any]:
+    """Return minimal capability information."""
+    return {}
+
+__all__ += [
+    "setup_logger",
+    "configure",
+    "measure_performance",
+    "detect_capabilities",
+]


### PR DESCRIPTION
## Summary
- avoid missing FileInput widget by using `Input`
- implement minimal renderers for text/HTML/ANSI/SVG
- provide placeholder transformers package
- add minimal CSS for TUI
- expose utilities and logger helpers

## Testing
- `pytest -q`
- `glyph-forge interactive --help`

------
https://chatgpt.com/codex/tasks/task_b_684d85a4ae3083239dafd952ada0023f